### PR TITLE
Allow ponysay to be reinstalled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ install:
 	mkdir -p $(DESTDIR)/usr/share/ponies
 	cp -r ponies/*.pony $(DESTDIR)/usr/share/ponies/
 	install -Dm755 ponysay $(DESTDIR)/usr/bin/ponysay
-	ln -s ponysay $(DESTDIR)/usr/bin/ponythink
+	ln -sf ponysay $(DESTDIR)/usr/bin/ponythink
 
 uninstall:
 	rm -fr $(DESTDIR)/usr/share/ponies


### PR DESCRIPTION
Force the linking of ponythink to ensure the makefile doesn't error if the link already exists.
