### PR TITLE
Repaired missing directories in isolated install enviroments and added make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,6 @@ uninstall:
 	if [ -e "$(DESTDIR)/usr/share/zsh/site-functions/_ponysay" ]; then unlink "$(DESTDIR)/usr/share/zsh/site-functions/_ponysay"; fi
 	unlink "$(DESTDIR)/usr/share/licenses/ponysay/COPYING"
 	unlink "$(DESTDIR)/usr/share/bash-completion/completions/ponysay"
+
+clean:
+	rm -r ponysaytruncater


### PR DESCRIPTION
For example in Gentoo, the packagemanager sets up an isolated install enviroment where the package have to create all directories the package needs, for examlpe /usr/bin

This have to be done in the package that someone maintains or by the Makefile in this case.

And say, if you want to install this in directory ~/target... you will have an empty directorytree where you install and will therefore need to create all dirs in the Makefile.
