### PR TITLE
Add missing dircategory and direntry to info document

### DIFF
--- a/manuals/ponysay.texinfo
+++ b/manuals/ponysay.texinfo
@@ -14,6 +14,10 @@
 @synindex op vr
 @synindex cp pg
 
+@dircategory Miscellaneous
+@direntry
+* ponysay: (ponysay).                Ponies for your terminal
+@end direntry
 
 @copying
 This manual is for ponysay


### PR DESCRIPTION
Please consider adding "@dircategory" and "@direntry" to the info document (this would solve a couple of minor issues pointed out by Debian's lintian tool, i.e. [info-document-missing-dir-entry](http://lintian.debian.org/tags/info-document-missing-dir-entry.html) and [info-document-missing-dir-section](http://lintian.debian.org/tags/info-document-missing-dir-section.html)). I'm not sure if "Miscellaneous" is the right category to list ponysay in, but I don't know if there's a more fitting category to choose from.
