### PR TITLE
argument parsing: Fixed code path for parsing --colour-pony accessing an undefined variable

### DIFF
--- a/src/ponysay.py
+++ b/src/ponysay.py
@@ -279,7 +279,7 @@ class Ponysay():
         '''
         ## Colouring features
         if self.__test_nfdnf('--colour-pony'):
-            self.mode += '\033[' + ';'.join(args.opts['--colour-pony']) + 'm'
+            self.mode += '\033[' + ';'.join(self.args.opts['--colour-pony']) + 'm'
         else:
             self.mode += '\033[0m'
         if self.__test_nfdnf('+c'):


### PR DESCRIPTION
It seems that the code path for --colour-pony does not work because of an access to an undefined variable:

```
$ ponysay --colour-pony 3 Yay
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/runpy.py", line 170, in _run_module_as_main
     "__main__", mod_spec)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/runpy.py", line 85, in _run_code
     exec(code, run_globals)
  File "venv/bin/ponysay/__main__.py", line 154, in <module>
  File "venv/bin/ponysay/ponysay.py", line 254, in run
  File "venv/bin/ponysay/ponysay.py", line 282, in __run
NameError: name 'args' is not defined
```

I do not know how and whether that feature is supposed to work but this fix prevents the exception from being thrown.
