### PR TITLE
Automatically collect a list of Python source files to add to the distribution.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ from subprocess import Popen, PIPE
 
 PONYSAY_VERSION = '3.0.3'
 
+project_dir = os.path.dirname(__file__)
+
 manpages = [('en', 'English'),  # must be first
             ('es', 'Spanish'),
             ('sv', 'Swedish'),
@@ -37,10 +39,7 @@ miscfiles = [('COPYING', '/usr/share/licenses/ponysay/COPYING'),
              ('LICENSE', '/usr/share/licenses/ponysay/LICENSE'),
              ('CREDITS', '/usr/share/licenses/ponysay/CREDITS')]
 
-ponysaysrc = [src + '.py' for src in
-              ('__main__', 'common', 'ponysay', 'argparser', 'balloon',
-               'backend', 'colourstack', 'ucs', 'spellocorrecter', 'kms',
-               'list', 'metadata', 'ponysaytool')]
+ponysaysrc = [i for i in os.listdir(os.path.join(project_dir, 'src')) if i.endswith('.py') and not i.startswith('.')]
 
 COPY = 'copy'
 HARD = 'hard'


### PR DESCRIPTION
While refactoring, I renamed the module `list` to `lists` to avoid confusion with the builtin of the same name. This led to the project not to build without also adjusting the list of source files to distribute in `setup.py`. I suggest that this list is build automatically from all Python files in the `src` directory.
