### PR TITLE
fix cjk char width

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -459,7 +459,7 @@ class Backend():
                 i += 1
                 if not UCS.isCombining(c):
                     rc += 1
-                    if unicodedata.east_asian_width(c) in ('W', 'A'):
+                    if unicodedata.east_asian_width(c) in ('F', 'W', 'A'):
                         rc += 1
         return rc
     

--- a/src/backend.py
+++ b/src/backend.py
@@ -34,6 +34,8 @@ from balloon import *
 from colourstack import *
 from ucs import *
 
+import unicodedata
+
 
 
 class Backend():
@@ -457,6 +459,8 @@ class Backend():
                 i += 1
                 if not UCS.isCombining(c):
                     rc += 1
+                    if unicodedata.east_asian_width(c) in ('W', 'A'):
+                        rc += 1
         return rc
     
     


### PR DESCRIPTION
CJK characters are (double) wider than normal chars.
This commit try to fix the width by counting the number of East Asian Width in 'W' (for wide) and 'A' (for ambiguous).

Reference: https://docs.python.org/3.4/library/unicodedata.html#unicodedata.east_asian_width
http://www.unicode.org/reports/tr11/