### PR TITLE
Updated setup.py (workaround for issue 229)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -922,7 +922,10 @@ class Setup():
         if target.startswith('./') or target.startswith('../'):
             os.symlink(target, dest)
         elif '/' not in target:
-            os.symlink('./' + target, dest)
+            try:
+                os.symlink('./' + target, dest)
+            except:
+                pass
         else:
             targets = target.split('/')
             dests = dest.split('/')


### PR DESCRIPTION
This adds a workaround for issue #229, placing the line into a `try`-`except` statement so that the installation doesn't (or at least shouldn't) come to a halt.