### PR TITLE
Updated setup.py (workaround for issue 229)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -922,7 +922,11 @@ class Setup():
         if target.startswith('./') or target.startswith('../'):
             os.symlink(target, dest)
         elif '/' not in target:
-            os.symlink('./' + target, dest)
+            try:
+                os.symlink('./' + target, dest)
+            except OSError as e:
+                if e.errno != 17:
+                    raise
         else:
             targets = target.split('/')
             dests = dest.split('/')


### PR DESCRIPTION
This is a workaround for issue #229, where an exception is thrown if the file exists. The `try` and `except` statement will ignore any "File exists" errors, but raise an exception for any others.