### PR TITLE
Fix unicode counting method

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -459,7 +459,7 @@ class Backend():
                 i += 1
                 if not UCS.isCombining(c):
                     rc += 1
-                    if unicodedata.east_asian_width(c) in ('F', 'W', 'A'):
+                    if unicodedata.east_asian_width(c) in ('F', 'W'):
                         rc += 1
         return rc
     


### PR DESCRIPTION
Ambiguous is *usually* 1 width, not 2. May break on some 2-width ambiguous chars. Fixes #227.