### PR TITLE
fix: do not compare literal with "is not"

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -291,7 +291,7 @@ class Backend():
                         props = dollar[7:]
                         if len(props) > 0:
                             if ',' in props:
-                                if props[0] is not ',':
+                                if props[0] != ',':
                                     w = props[:props.index(',')]
                                 h = int(props[props.index(',') + 1:])
                             else:


### PR DESCRIPTION
Python3.8 issued the following warning on each ponysay invocation:

/bin/ponysay/backend.py:294: SyntaxWarning: "is not" with a literal. Did you mean "!="?

This has been corrected here.