### PR TITLE
fix incorrect install dir for fish completion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ sharefiles = [('ucs', 'ucsmap')]
 commands = ['ponysay', 'ponythink', 'ponysay-tool']
 
 shells = [('bash', '/usr/share/bash-completion/completions/ponysay', 'GNU Bash'),
-          ('fish', '/usr/share/fish/completions/ponysay.fish', 'Friendly interactive shell'),
+          ('fish', '/usr/share/fish/vendor_completions.d/ponysay.fish', 'Friendly interactive shell'),
           ('zsh', '/usr/share/zsh/site-functions/_ponysay', 'zsh')]
 
 mansections = [('ponysay', '6'),


### PR DESCRIPTION
fish completions should never be installed to share/fish/completions/ as that directory is reserved exclusively for completions shipped as part of the fish source code.

Use the same vendor_completions.d/ directory which the default fish configuration uses.