### PR TITLE
fix: do not compare literal with "is not"

### DIFF
--- a/src/ponysaytool.py
+++ b/src/ponysaytool.py
@@ -1002,7 +1002,7 @@ class TextArea(): # TODO support small screens  (This is being work on in GNU-Po
                     for row in range(0, len(datalines)):
                         current = leftlines[row]
                         if len(datalines[row].strip()) == 0:
-                            if current is not 'comment':
+                            if current != 'comment':
                                 if current != last:
                                     self.datamap[current] = None
                                 continue


### PR DESCRIPTION
ponysaytool.py:1005: SyntaxWarning: "is not" with a literal. Did you mean "!="?