### PR TITLE
add `texinfo` as a dependency during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Dependencies
 
 `python>=3`: `ponysay` is written in Python 3.
 
+`texinfo`: for generating documentation during the installation.
+
 ### Package building dependencies
 
 `gzip`: Used for compressing manuals (suppressable with `./configure --without-info-compression --without-man-compression`).


### PR DESCRIPTION
Effectively `texinfo` seems to be a dependency, because running the setup of ponysay did not complete successfully unless I installed `texinfo`.
Here is the output of the install process, which failed because `makeinfo` was missing:
```
$ sudo python3 ./setup.py --freedom=partial install

Installing command ponysay as /usr/bin/ponysay
Installing command ponythink as /usr/bin/ponythink
Installing command ponysay-tool as /usr/bin/ponysay-tool
Installing shared cache at /var/cache/ponysay
Installing auto-completion for bash as /usr/share/bash-completion/completions/ponysay
Installing auto-completion for fish as /usr/share/fish/vendor_completions.d/ponysay.fish
Installing auto-completion for zsh as /usr/share/zsh/site-functions/_ponysay
Skipping installation of PDF manual
Skipping compression of PDF manual
Installing info manual to /usr/share/info
Installing info manual with install-info with description: My Little Ponies for your terminal
Compressing info manual with gz
Installing English manpage to /usr/share/man
Compressing English manpage with gz
Skipping installation of Spanish manpage
Compressing Spanish manpage with gz
Skipping installation of Swedish manpage
Compressing Swedish manpage with gz
Skipping installation of Turkish manpage
Compressing Turkish manpage with gz
References to manpage for ponysay points to section 6
References to manpage for cowsay points to section 1
References to manpage for fortune points to section 6
References to manpage for ponysay-tool points to section 6
Installing xterm ponies to /usr/share/ponysay/ponies
Installing tty ponies to /usr/share/ponysay/ttyponies
Installing extra xterm ponies to /usr/share/ponysay/extraponies
Installing extra tty ponies to /usr/share/ponysay/extrattyponies
Installing pony quotes to /usr/share/ponysay/quotes
Installing balloon styles to /usr/share/ponysay/balloons
Installing ucsmap as /usr/share/ponysay/ucs
Looking for best env reference in python script shebang
Installing COPYING to /usr/share/licenses/ponysay/COPYING
Installing LICENSE to /usr/share/licenses/ponysay/LICENSE
Installing CREDITS to /usr/share/licenses/ponysay/CREDITS
Using system configuration directory: /etc
Prefered linking style: symbolic
Using umask: 022 (only owner can do modifications)
Installing not only fully free parts of the package

::Compiling...
Creating uncompressed zip file ponysay.zip with files from src: ponysaytool.py backend.py argparser.py kms.py ucs.py colourstack.py lists.py spellocorrecter.py metadata.py __main__.py ponysay.py balloon.py common.py
gzip -9 -f < manuals/manpage.6.install > manuals/manpage.6.gz
makeinfo manuals/ponysay.texinfo
sh: 1: makeinfo: not found
gzip -9 -f < ponysay.info > ponysay.info.gz
Traceback (most recent call last):
  File "./setup.py", line 1239, in <module>
    Setup()
  File "./setup.py", line 295, in __init__
    self.build(conf)
  File "./setup.py", line 477, in build
    compress('ponysay.info', 'ponysay.info.' + ext, ext)
  File "./setup.py", line 383, in compress
    filein = open(source, 'r')
FileNotFoundError: [Errno 2] No such file or directory: 'ponysay.info'
```