### PR TITLE
Fix visuals, --restrict

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,12 @@ Version 3.0.4
 
         Fixed incorrect install dir for fish completion.
 
+        Switched to using ANSI code 0 to reset boldness.
+
+        Fixed a pony's metadata which caused --restrict to break.
+
+        Fixed an unescaped backslash to prevent a Python warning.
+
 version 3.0.3
 
 	New ponies: auntorange, caballeron, cocopommel, coloratura, coriander, 

--- a/manuals/ponysay.texinfo
+++ b/manuals/ponysay.texinfo
@@ -3414,6 +3414,12 @@ ANSI escape sequences.
 @itemize @bullet
 @item
 New extraponies: @file{raripunk}, @file{smolder}, @file{solarflare}
+@item
+Switched to using ANSI code 0 to reset boldness.
+@item
+Fixed a pony's metadata which caused --restrict to break.
+@item
+Fixed an unescaped backslash to prevent a Python warning.
 
 @end itemize
 

--- a/ponies/raritysdad.pony
+++ b/ponies/raritysdad.pony
@@ -12,7 +12,7 @@ KIND: earth
 LINK: regular
 MANE: black
 NAME: (not mentioned)
-OTHER NAMES: Magnum (official, in Gameloft game), Hondo Flanks (official. on Trading Card Game}, Carlton (unofficial)
+OTHER NAMES: Magnum (official, in Gameloft game), Hondo Flanks (official, on Trading Card Game), Carlton (unofficial)
 POSE: stand
 SOURCE: (Bot-chan) Desktop ponies
 WIDTH: 41

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ SYMBOLIC = 'symbolic'
 
 class Setup():
     def __init__(self):
-        usage_script = '\033[34;1msetup.py\033[21;39m'
+        usage_script = '\033[34;1msetup.py\033[0;39m'
         usage_help   = '(--version | --help)'
         usage_proc   = '[\033[4mconfigurations\033[24m] ([build] | prebuilt | install | (uninstall|clean)[-old] | view)'
 
@@ -358,9 +358,9 @@ class Setup():
         print('Using system configuration directory: ' + conf['sysconf-dir'])
         print('Prefered linking style: ' + self.linking)
         print('Using umask: 022 (only owner can do modifications)')
-        if self.free is None:                      print(YELLOW % ('\033[01m--freedom is manditory and has not be specified\033[21m'))
+        if self.free is None:                      print(YELLOW % ('\033[01m--freedom is manditory and has not be specified\033[0m'))
         elif self.free:                            print(GREEN  % ('', 'Installing only fully free parts of the package'))
-        else:                                      print(RED    % ('Installing \033[1mnot\033[21m only fully free parts of the package'))
+        else:                                      print(RED    % ('Installing \033[1mnot\033[0m only fully free parts of the package'))
 
         print()
     
@@ -369,7 +369,7 @@ class Setup():
         Compile ponysay
         '''
         
-        print('\033[1;34m::\033[39mCompiling...\033[21m')
+        print('\033[1;34m::\033[39mCompiling...\033[0m')
 
         def compressCommand(ext):
             if ext == 'gz':  return 'gzip -9 -f'
@@ -575,7 +575,7 @@ class Setup():
         Install compiled ponysay
         '''
         
-        print('\033[1;34m::\033[39mInstalling...\033[21m')
+        print('\033[1;34m::\033[39mInstalling...\033[0m')
 
         dests = []
         for command in commands:
@@ -665,7 +665,7 @@ class Setup():
         Uninstall ponysay
         '''
         
-        print('\033[1;34m::\033[39mUninstalling...\033[21m')
+        print('\033[1;34m::\033[39mUninstalling...\033[0m')
 
         (files, dirs, infos) = ([], [], [])
 
@@ -723,7 +723,7 @@ class Setup():
         Uninstall file ponysay no longer uses
         '''
         
-        print('\033[1;34m::\033[39mUninstalling old files...\033[21m')
+        print('\033[1;34m::\033[39mUninstalling old files...\033[0m')
 
         instdir = conf['~prefix~'] + '/usr'
         files = [instdir + f for f in ['bin/ponysaylist.pl', 'bin/ponysaytruncater', 'bin/ponysay.py', 'bin/ponythink.py']]
@@ -744,7 +744,7 @@ class Setup():
         Remove compiled files
         '''
         
-        print('\033[1;34m::\033[39mCleaning...\033[21m')
+        print('\033[1;34m::\033[39mCleaning...\033[0m')
 
         files = ['ponysay.info', 'ponysay.info.gz', 'ponysay.info.xz',  'ponysay.pdf.gz', 'ponysay.pdf.xz', 'ponysay.install', 'ponysay.zip']
         files += ['src/%s.install' % file for file in ponysaysrc]
@@ -771,7 +771,7 @@ class Setup():
         Remove compiled files ponysay is no longer compiling
         '''
         
-        print('\033[1;34m::\033[39mCleaning old files...\033[21m')
+        print('\033[1;34m::\033[39mCleaning old files...\033[0m')
 
         files = ['truncater', 'ponysaytruncater', 'ponysay.py.install', 'ponysay.install~', 'ponysay.zip']
         dirs = []
@@ -1199,7 +1199,7 @@ class ArgParser():
         if self.__longdescription is not None:
             print(self.__longdescription)
             print()
-        print('\n\033[1mUSAGE:\033[21m', end='')
+        print('\n\033[1mUSAGE:\033[0m', end='')
         first = True
         for line in self.__usage.split('\n'):
             if first:  first = False
@@ -1214,11 +1214,11 @@ class ArgParser():
         '''
         
         # The usage should be terse so this header is only included in the help command.
-        print('\033[1m{}\033[21m - {}\n'.format(self.__program, self.__description))
+        print('\033[1m{}\033[0m - {}\n'.format(self.__program, self.__description))
         
         self.usage()
         
-        print('\033[1mCONFIGURATIONS:\033[21m\n')
+        print('\033[1mCONFIGURATIONS:\033[0m\n')
         for opt in self.__arguments:
             (opt_type, opt_alts, opt_arg, opt_help) = opt[0:4]
             if opt_help is not None:
@@ -1229,7 +1229,7 @@ class ArgParser():
                         print('\t\033[2m' + opt_alt + '\033[22m')
                 first = True
                 for line in opt_help.split('\n'):
-                    print(('\t\t\033[32;1m%s\033[21;39m' if first else '\t\t%s') % (line))
+                    print(('\t\t\033[32;1m%s\033[0;39m' if first else '\t\t%s') % (line))
                     first = False
                 print()
         print()

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
         isthink = isthink[:isthink.find(os.extsep)]
     isthink = isthink.endswith('think')
     
-    usage_saythink = '\033[34;1m(ponysay | ponythink)\033[21;39m'
+    usage_saythink = '\033[34;1m(ponysay | ponythink)\033[0;39m'
     usage_common   = '[-c] [-W\033[33mCOLUMN\033[39m] [-b\033[33mSTYLE\033[39m]'
     usage_listhelp = '(-l | -L | -B | +l | +L | -A | + A | -v | -h)'
     usage_file     = '[-f\033[33mPONY\033[39m]* [[--] \033[33mmessage\033[39m]'

--- a/src/argparser.py
+++ b/src/argparser.py
@@ -254,7 +254,7 @@ class ArgParser():
         if use_colours is None:
             use_colours = sys.stdout.isatty()
         
-        print(('\033[1m%s\033[21m %s %s' if use_colours else '%s %s %s') % (self.__program, '-' if self.linuxvt else '—', self.__description))
+        print(('\033[1m%s\033[0m %s %s' if use_colours else '%s %s %s') % (self.__program, '-' if self.linuxvt else '—', self.__description))
         print()
         if self.__longdescription is not None:
             desc = self.__longdescription
@@ -265,7 +265,7 @@ class ArgParser():
             print(desc)
         print()
         
-        print('\033[1mUSAGE:\033[21m' if use_colours else 'USAGE:', end='')
+        print('\033[1mUSAGE:\033[0m' if use_colours else 'USAGE:', end='')
         first = True
         for line in self.__usage.split('\n'):
             if first:
@@ -291,7 +291,7 @@ class ArgParser():
                 maxfirstlen.append(first)
         maxfirstlen = len(max(maxfirstlen, key = len))
         
-        print('\033[1mSYNOPSIS:\033[21m' if use_colours else 'SYNOPSIS')
+        print('\033[1mSYNOPSIS:\033[0m' if use_colours else 'SYNOPSIS')
         (lines, lens) = ([], [])
         for opt in self.__arguments:
             opt_type = opt[0]
@@ -337,7 +337,7 @@ class ArgParser():
             for line in opt_help.split('\n'):
                 if first:
                     first = False
-                    print('%s' % (line), end='\033[21;39m\n' if use_colours else '\n')
+                    print('%s' % (line), end='\033[0;39m\n' if use_colours else '\n')
                 else:
                     print(('%s\033[%sm%s\033[39m' if use_colours else '%s%s%s') % (' ' * col, colour, line))
             index += 1

--- a/src/backend.py
+++ b/src/backend.py
@@ -118,7 +118,7 @@ class Backend():
                 printinfo(info)
                 self.pony = self.pony[infoend:]
         elif self.infolevel == 2:
-            self.message = '\033[01;31mI am the mysterious mare...\033[21;39m'
+            self.message = '\033[01;31mI am the mysterious mare...\033[0;39m'
         elif self.infolevel == 1:
             self.pony = 'There is not metadata for this pony file'
         self.pony = self.mode + self.pony
@@ -149,7 +149,7 @@ class Backend():
                     test = test.replace(c, '')
                 if (len(test) == 0) and (len(key.replace(' ', '')) > 0):
                     value = line[sep + 1:].strip()
-                    line = '\033[1m%s\033[21m: %s\n' % (key.strip(), value)
+                    line = '\033[1m%s\033[0m: %s\n' % (key.strip(), value)
                     tags += line
                     continue
             comment += '\n' + line

--- a/src/balloon.py
+++ b/src/balloon.py
@@ -43,9 +43,9 @@ class Balloon():
         '''
         Constructor
         
-        @param  link:str        The \-directional balloon line character
+        @param  link:str        The \\-directional balloon line character
         @param  linkmirror:str  The /-directional balloon line character
-        @param  linkcross:str   The /-directional balloon crossing a \-directional ballonon line character
+        @param  linkcross:str   The /-directional balloon crossing a \\-directional ballonon line character
         @param  ww:str          See the info manual
         @param  ee:str          See the info manual
         @param  nw:list<str>    See the info manual

--- a/src/balloon.py
+++ b/src/balloon.py
@@ -40,12 +40,12 @@ class Balloon():
     '''
     
     def __init__(self, link, linkmirror, linkcross, ww, ee, nw, nnw, n, nne, ne, nee, e, see, se, sse, s, ssw, sw, sww, w, nww):
-        '''
+        r'''
         Constructor
         
-        @param  link:str        The \\-directional balloon line character
+        @param  link:str        The \-directional balloon line character
         @param  linkmirror:str  The /-directional balloon line character
-        @param  linkcross:str   The /-directional balloon crossing a \\-directional ballonon line character
+        @param  linkcross:str   The /-directional balloon crossing a \-directional ballonon line character
         @param  ww:str          See the info manual
         @param  ee:str          See the info manual
         @param  nw:list<str>    See the info manual

--- a/src/lists.py
+++ b/src/lists.py
@@ -125,8 +125,8 @@ def simplelist(ponydirs, quoters = [], ucsiser = None):
         ## If ther directory is not empty print its name and all ponies, columnised
         if len(ponies) == 0:
             continue
-        print('\033[1mponies located in ' + ponydir + '\033[21m')
-        _print_columnised([(pony, '\033[1m' + pony + '\033[21m' if pony in quoters else pony) for pony in ponies])
+        print('\033[1mponies located in ' + ponydir + '\033[0m')
+        _print_columnised([(pony, '\033[1m' + pony + '\033[0m' if pony in quoters else pony) for pony in ponies])
 
 
 def linklist(ponydirs = None, quoters = [], ucsiser = None):
@@ -145,7 +145,7 @@ def linklist(ponydirs = None, quoters = [], ucsiser = None):
         ## If there are no ponies in the directory skip to next directory, otherwise, print the directories name
         if len(ponies) == 0:
             continue
-        print('\033[1mponies located in ' + ponydir + '\033[21m')
+        print('\033[1mponies located in ' + ponydir + '\033[0m')
         
         ## UCS:ise pony names
         pseudolinkmap = {}
@@ -179,7 +179,7 @@ def linklist(ponydirs = None, quoters = [], ucsiser = None):
         ponies = {}
         for pony in ponymap:
             w = UCS.dispLen(pony)
-            item = '\033[1m' + pony + '\033[21m' if (pony in quoters) else pony
+            item = '\033[1m' + pony + '\033[0m' if (pony in quoters) else pony
             syms = ponymap[pony]
             syms.sort()
             if len(syms) > 0:
@@ -190,9 +190,9 @@ def linklist(ponydirs = None, quoters = [], ucsiser = None):
                     w += UCS.dispLen(sym)
                     if first:  first = False
                     else:      item += ' '
-                    item += '\033[1m' + sym + '\033[21m' if (sym in quoters) else sym
+                    item += '\033[1m' + sym + '\033[0m' if (sym in quoters) else sym
                 item += ')'
-            ponies[(item.replace('\033[1m', '').replace('\033[21m', ''), item)] = w
+            ponies[(item.replace('\033[1m', '').replace('\033[0m', ''), item)] = w
         
         ## Print the ponies, columnised
         _print_columnised(list(ponies))

--- a/src/ponysaytool.py
+++ b/src/ponysaytool.py
@@ -275,7 +275,7 @@ class PonysayTool():
         ponies.sort()
         
         if len(ponies) == 0:
-            print('\033[1;31m%s\033[21m;39m' % 'No ponies... press Enter to exit.')
+            print('\033[1;31m%s\033[0m;39m' % 'No ponies... press Enter to exit.')
             input()
         
         panelw = Backend.len(max(ponies, key = Backend.len))
@@ -338,7 +338,7 @@ class PonysayTool():
                     elif px > 0:
                         ponyprint = [px * ' ' + line for line in ponyprint]
                     ponyprint = [(line if Backend.len(line) <= termw else line[:findcolumn(line, termw)]) for line in ponyprint]
-                    ponyprint = ['\033[21;39;49;0m%s\033[21;39;49;0m' % line for line in ponyprint]
+                    ponyprint = ['\033[0;39;49;0m%s\033[0;39;49;0m' % line for line in ponyprint]
                     return '\n'.join(ponyprint)
                 
                 if quotes:
@@ -774,7 +774,7 @@ class PonysayTool():
             buf += c + colourstack.feed(c)
         modprintpony = buf.replace(AUTO_PUSH, '').replace(AUTO_POP, '')
         
-        printpony = [('\033[21;39;49;0m%s%s\033[21;39;49;0m' % (' ' * (termsize[1] - ponywidth), line)) for line in modprintpony.split('\n')]
+        printpony = [('\033[0;39;49;0m%s%s\033[0;39;49;0m' % (' ' * (termsize[1] - ponywidth), line)) for line in modprintpony.split('\n')]
         
         
         print(preprint, end='')
@@ -922,9 +922,9 @@ class TextArea(): # TODO support small screens  (This is being work on in GNU-Po
                 else:
                     print('\033[%i;%iH\033[34m%s:\033[39m' % (self.top + oldy, self.left, leftlines[oldy]), end='')
                 if (y > 0) and (leftlines[y - 1] == leftlines[y]) and (leftlines[y] == leftlines[-1]):
-                    print('\033[%i;%iH\033[1;34m%s\033[21;39m' % (self.top + y, self.left, '>'), end='')
+                    print('\033[%i;%iH\033[1;34m%s\033[0;39m' % (self.top + y, self.left, '>'), end='')
                 else:
-                    print('\033[%i;%iH\033[1;34m%s:\033[21;39m' % (self.top + y, self.left, leftlines[y]), end='')
+                    print('\033[%i;%iH\033[1;34m%s:\033[0;39m' % (self.top + y, self.left, leftlines[y]), end='')
                 print('\033[%i;%iH' % (self.top + y, innerleft + x), end='')
             (oldy, oldx, oldmark) = (y, x, mark)
             if edited:
@@ -1080,7 +1080,7 @@ class TextArea(): # TODO support small screens  (This is being work on in GNU-Po
                         leftline = leftlines[row] + ':'
                         if (leftlines[row - 1] == leftlines[row]) and (leftlines[row] == leftlines[-1]):
                             leftline = '>'
-                        print('\033[%i;%iH\033[%s34m%s\033[%s39m' % (self.top + row, self.left, '1;' if row == y else '', leftline, '21;' if row == y else ''), end='')
+                        print('\033[%i;%iH\033[%s34m%s\033[%s39m' % (self.top + row, self.left, '1;' if row == y else '', leftline, '0;' if row == y else ''), end='')
                     for row in range(0, len(datalines)):
                         print('\033[%i;%iH%s\033[49m' % (self.top + row, innerleft, datalines[row]), end='')
                     print('\033[%i;%iH' % (self.top + y, innerleft + x), end='')
@@ -1206,7 +1206,7 @@ Whether stderr is piped
 '''
 
 
-usage_program = '\033[34;1mponysay-tool\033[21;39m'
+usage_program = '\033[34;1mponysay-tool\033[0;39m'
 
 usage = '\n'.join(['%s %s' % (usage_program, '(--help | --version | --kms)'),
                    '%s %s' % (usage_program, '(--edit | --edit-rm) \033[33mPONY-FILE\033[39m'),


### PR DESCRIPTION
I have fixed three things:

**Default ANSI code** 
Ponysay was using the "21" ANSI code to reset boldness; however, this functionality does not seem to be widely supported (see [this gist](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797) or [this answer](https://stackoverflow.com/a/33206814)). On my terminal, for example, it serves as double-underline, leading to a very ugly help message. For this reason, I have replaced the code with a "0", as that is a universal reset.

**Fix --restrict**
There was an unmatched bracket in a pony's metadata which led to the "metadata" file not being created on setup. This fixes [issue #266](https://github.com/erkin/ponysay/issues/266), making the --restrict option work again.

**Backslash escaping**
There was an instance of a docstring using unescaped backslashes, which in turn threw Python warnings.