### PR TITLE
Bugfix: SyntaxWarning: invalid escape sequence '\-'

### DIFF
--- a/src/balloon.py
+++ b/src/balloon.py
@@ -43,9 +43,9 @@ class Balloon():
         '''
         Constructor
         
-        @param  link:str        The \-directional balloon line character
+        @param  link:str        The \\-directional balloon line character
         @param  linkmirror:str  The /-directional balloon line character
-        @param  linkcross:str   The /-directional balloon crossing a \-directional ballonon line character
+        @param  linkcross:str   The /-directional balloon crossing a \\-directional ballonon line character
         @param  ww:str          See the info manual
         @param  ee:str          See the info manual
         @param  nw:list<str>    See the info manual


### PR DESCRIPTION
I get the following error when running the latest ponysay on Python 3.12:

```
/usr/local/bin/ponysay/balloon.py:43: SyntaxWarning: invalid escape sequence '\-'
/usr/local/bin/ponysay/balloon.py:43: SyntaxWarning: invalid escape sequence '\-'
```

I believe the changes I made fix the issue, and the error is no longer present. However, I had trouble running ponysay directly from source, so I could only verify this by replicating the issue with a simple program and then issuing this fix.