### PR TITLE
Fix SyntaxWarnings

### DIFF
--- a/src/balloon.py
+++ b/src/balloon.py
@@ -40,7 +40,7 @@ class Balloon():
     '''
     
     def __init__(self, link, linkmirror, linkcross, ww, ee, nw, nnw, n, nne, ne, nee, e, see, se, sse, s, ssw, sw, sww, w, nww):
-        '''
+        r'''
         Constructor
         
         @param  link:str        The \-directional balloon line character


### PR DESCRIPTION
Fixes https://github.com/erkin/ponysay/issues/321

Currently when running ponysay, you get this warning twice:

```
/nix/store/.../bin/ponysay/balloon.py:43: SyntaxWarning: invalid escape sequence '-'
```

It is caused by a docstring containing twice the phrase `\-directional`.

The fix is just to make it a raw string (replace `'''` with `r'''`).